### PR TITLE
feat(talk-and-events): microCMSから登壇・イベント履歴を取得・表示

### DIFF
--- a/src/api/talkAndEvents.ts
+++ b/src/api/talkAndEvents.ts
@@ -1,0 +1,10 @@
+import { TalkAndEventResponse } from '@/types'
+import { initMicroCms } from './axios'
+
+export const fetchTalkAndEventList = async () => {
+  const list = await initMicroCms()
+    .get<TalkAndEventResponse>('talk-and-events?limit=100')
+    .then((res) => res.data)
+  return list
+}
+

--- a/src/components/Index/elements/TalkAndEventBody/index.tsx
+++ b/src/components/Index/elements/TalkAndEventBody/index.tsx
@@ -1,4 +1,6 @@
-import Image from 'next/image'
+import { UseFetchTalkAndEvents } from '@/hooks/talkAndEventsHooks'
+import { formatTime2Ymd } from '@/utils/function'
+import { useQuery } from 'react-query'
 import {
   companyImage,
   companyImageContainer,
@@ -13,42 +15,38 @@ import {
   talkAndEventBodyWrapper,
 } from './styles/talkAndEventBody.css'
 
-const histories = [
-  {
-    id: 2,
-    company: 'フロントエンドカンファレンス北海道2024',
-    job: 'スポンサーLT',
-    period: '2024/08/27',
-    src: 'https://x.com/0e2b3c/status/1827180443227320707',
-  },
-  {
-    id: 1,
-    company: 'CTO研修 ISUCON研修おかわり会',
-    job: '主催',
-    period: '2025/06/26',
-  },
-]
-const reversedHistories = histories.reverse()
-
 export const TalkAndEventBody = () => {
+  const { data, isLoading, isError } = useQuery(
+    'talk-and-events',
+    UseFetchTalkAndEvents,
+    { refetchOnWindowFocus: false }
+  )
+
+  if (isLoading) return null
+  if (isError) return null
+
+  const items = (data?.contents ?? [])
+    .slice()
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+
   return (
     <section className={talkAndEventBodyWrapper}>
       <div className={talkAndEventBody}>
         <ul className={talkAndEventBodyInner}>
-          {reversedHistories.map((history) => {
+          {items.map((item) => {
             return (
-              <li className={historyItem} key={history.id}>
+              <li className={historyItem} key={item.id}>
                 <div className={[historyItemInner].join(' ')}>
                   <div>
                     <a
                       className={link}
-                      href={history.src || ''}
+                      href={item.src || '#'}
                       target='_blank'
                       rel='noopener noreferrer'
                     >
-                      <p className={period}>{history.period}</p>
-                      <p className={companyName}>{history.company}</p>
-                      <p className={job}>{history.job}</p>
+                      <p className={period}>{formatTime2Ymd(item.date)}</p>
+                      <p className={companyName}>{item.title}</p>
+                      <p className={job}>{item.subTitle}</p>
                     </a>
                   </div>
                 </div>

--- a/src/components/Index/elements/TalkAndEventBody/styles/talkAndEventBody.css.ts
+++ b/src/components/Index/elements/TalkAndEventBody/styles/talkAndEventBody.css.ts
@@ -82,6 +82,7 @@ export const companyName = style({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  fontWeight: 'bold',
 })
 
 export const job = style({

--- a/src/hooks/talkAndEventsHooks.ts
+++ b/src/hooks/talkAndEventsHooks.ts
@@ -1,0 +1,7 @@
+import { TalkAndEventResponse } from '@/types'
+
+export const UseFetchTalkAndEvents = async (): Promise<TalkAndEventResponse> => {
+  const res = await fetch('/api/talk-and-events/list')
+  return res.json()
+}
+

--- a/src/pages/api/talk-and-events/list.ts
+++ b/src/pages/api/talk-and-events/list.ts
@@ -1,0 +1,12 @@
+import { fetchTalkAndEventList } from '@/api/talkAndEvents'
+import { TalkAndEventResponse } from '@/types'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<TalkAndEventResponse>
+) {
+  const list = await fetchTalkAndEventList()
+  res.status(200).json(list)
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,3 +63,22 @@ export type TableOfContent = {
 	title: string
 	href: string
 }
+
+export type TalkAndEvent = {
+  id: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+  title: string
+  subTitle?: string
+  date: string
+  src?: string
+}
+
+export type TalkAndEventResponse = {
+  contents?: TalkAndEvent[]
+  totalCount?: number
+  offset?: number
+  limit?: number
+}


### PR DESCRIPTION
\n\n- types: TalkAndE…vent型を追加\n- api: talk-and-eventsフェッチ関数を追加\n- api route: /api/talk-and-events/list を追加\n- hook: UseFetchTalkAndEvents を追加\n- component: TalkAndEventBody をAPIレスポンスのプロパティに合わせて表示し、日付降順で並べ替え